### PR TITLE
Handle ChromecastConnectionError

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,10 @@ app.config.update({
 
 def get_chromecast():
     """Returns a connection to the Chromecast."""
-    return pychromecast.Chromecast(app.config['CHROMECAST_IP'])
+    try:
+        return pychromecast.Chromecast(app.config['CHROMECAST_IP'])
+    except pychromecast.ChromecastConnectionError:
+        pass
 
 
 def get_media():


### PR DESCRIPTION
This will display an alert message when a Chromecast cannot be found via the
given IP address:

> Error! Chromecast not found.

Fixes #7 
