### PR TITLE
Return to idle screen on /stop

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,6 +118,7 @@ def stop():
     time.sleep(1)
 
     chromecast.media_controller.stop()
+    chromecast.quit_app()
 
     return redirect(url_for('index'))
 


### PR DESCRIPTION
This commit invokes `chromecast.quit_app()` after stopping playback of
some media on the Chromecast via the `/stop` endpoint. This returns the
Chromecast to the idle screen with rotating wallpapers immediately after
the user stops playback of a movie.
